### PR TITLE
Naming inconsistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.1",
   "description": "Masonry gallery layout component for Vue.js",
   "author": "Vajracode <support@vajracode.com>",
-  "main": "./vendor/vueMasonryGallery/vueMasonryGallery.js",
+  "main": "./vendor/VueMasonryGallery/VueMasonryGallery.js",
   "keywords": [
     "Vue",
     "Vue project",


### PR DESCRIPTION
This would cause webpack to fail loading the plugin:

```
 ERROR  Failed to compile with 1 errors                                                                                                        
This dependency was not found:

* vue-masonry-gallery in ./node_modules/cache-loader/dist/cjs.js??ref--12-0!./node_modules/babel-loader/lib!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./src/App.vue?vue&type=script&lang=js&

To install it, you can run: npm install --save vue-masonry-gallery
```